### PR TITLE
Fix Django 1.6 _has_changed() incompatibility

### DIFF
--- a/runtests.py
+++ b/runtests.py
@@ -19,6 +19,7 @@ if not settings.configured:
         SITE_ID=1,
         SECRET_KEY='super-secret',
         ROOT_URLCONF='selectable.tests.urls',
+        TEST_RUNNER='django.test.simple.DjangoTestSuiteRunner',
     )
 
 

--- a/selectable/forms/fields.py
+++ b/selectable/forms/fields.py
@@ -31,6 +31,14 @@ class AutoCompleteSelectField(forms.Field):
             kwargs['widget'] = widget(lookup_class, allow_new=self.allow_new, limit=self.limit)
         super(AutoCompleteSelectField, self).__init__(*args, **kwargs)
 
+    def _has_changed(self, initial, data):
+        "Detects if the data was changed. This is added in 1.6."
+        if initial is None and data is None:
+            return False
+        if data and not hasattr(data, '__iter__'):
+            data = self.widget.decompress(data)
+        initial = self.to_python(initial)
+        return super(AutoCompleteSelectField, self)._has_changed(initial, data)
 
     def to_python(self, value):
         if value in EMPTY_VALUES:
@@ -76,6 +84,15 @@ class AutoCompleteSelectMultipleField(forms.Field):
         if isinstance(widget, type):
             kwargs['widget'] = widget(lookup_class, limit=self.limit)
         super(AutoCompleteSelectMultipleField, self).__init__(*args, **kwargs)
+
+    def _has_changed(self, initial, data):
+        "Detects if the data was changed. This is added in 1.6."
+        if initial is None and data is None:
+            return False
+        if data and not hasattr(data, '__iter__'):
+            data = self.widget.decompress(data)
+        initial = self.to_python(initial)
+        return super(AutoCompleteSelectMultipleField, self)._has_changed(initial, data)
 
     def to_python(self, value):
         if value in EMPTY_VALUES:

--- a/selectable/forms/widgets.py
+++ b/selectable/forms/widgets.py
@@ -2,7 +2,7 @@ from __future__ import unicode_literals
 
 import json
 
-from django import forms
+from django import forms, VERSION as DJANGO_VERSION
 from django.conf import settings
 from django.forms.util import flatatt
 from django.utils.http import urlencode
@@ -65,13 +65,14 @@ class SelectableMultiWidget(forms.MultiWidget):
     def update_query_parameters(self, qs_dict):
         self.widgets[0].update_query_parameters(qs_dict)
 
-    def _has_changed(self, initial, data):
-        "Decects if the widget was changed. This is removed in 1.6."
-        if initial is None and data is None:
-            return False
-        if data and not hasattr(data, '__iter__'):
-            data = self.decompress(data)
-        return super(SelectableMultiWidget, self)._has_changed(initial, data)
+    if DJANGO_VERSION < (1, 6):
+        def _has_changed(self, initial, data):
+            "Detects if the widget was changed. This is removed in Django 1.6."
+            if initial is None and data is None:
+                return False
+            if data and not hasattr(data, '__iter__'):
+                data = self.decompress(data)
+            return super(SelectableMultiWidget, self)._has_changed(initial, data)
 
     def decompress(self, value):
         if value:
@@ -230,15 +231,16 @@ class _BaseMultipleSelectWidget(SelectableMultiWidget, SelectableMediaMixin):
         value = ['', value]
         return super(_BaseMultipleSelectWidget, self).render(name, value, attrs)
 
-    def _has_changed(self, initial, data):
-        """"
-        Decects if the widget was changed. This is removed in 1.6.
+    if DJANGO_VERSION < (1, 6):
+        def _has_changed(self, initial, data):
+            """"
+            Detects if the widget was changed. This is removed in Django 1.6.
 
-        For the multi-select case we only care if the hidden inputs changed.
-        """
-        initial = ['', initial]
-        data = ['', data]
-        return super(_BaseMultipleSelectWidget, self)._has_changed(initial, data)
+            For the multi-select case we only care if the hidden inputs changed.
+            """
+            initial = ['', initial]
+            data = ['', data]
+            return super(_BaseMultipleSelectWidget, self)._has_changed(initial, data)
 
 
 class AutoCompleteSelectMultipleWidget(_BaseMultipleSelectWidget):


### PR DESCRIPTION
In Django 1.6, Django forms dropped the _has_changed() method from their own
widgets, and want to call it on fields instead.

Also includes a workaround for the Django 1.6 test runner not finding
django-selectable's tests (using the old test runner).
