### PR TITLE
Fixing example requirements.txt

### DIFF
--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,3 @@
 django>=1.4
+django-localflavor
 django-selectable


### PR DESCRIPTION
Hi,

I tried to run given example, but running `python manage.py runserver 9000` in `django-selectable/example/` crashed.
`localflavor` was missing. So I added it to `requirements.txt`, it seems to be working.
I hope it suits you.

Regards
