### PR TITLE
 Automate Chained Selection

### DIFF
--- a/example/core/forms.py
+++ b/example/core/forms.py
@@ -10,7 +10,7 @@ import selectable.forms as selectable
 
 from core.lookups import FruitLookup, CityLookup
 from core.models import Farm
-
+from selectable.registry import chained_field
 
 class FruitForm(forms.Form):
     autocomplete = forms.CharField(
@@ -75,7 +75,7 @@ class FruitForm(forms.Form):
         widget=selectable.AutoComboboxSelectMultipleWidget
     )
 
-
+@chained_field('city', 'state')
 class ChainedForm(forms.Form):
     city = selectable.AutoCompleteSelectField(
         lookup_class=CityLookup,

--- a/example/core/lookups.py
+++ b/example/core/lookups.py
@@ -27,13 +27,6 @@ class CityLookup(ModelLookup):
     model = City
     search_fields = ('name__icontains', )
 
-    def get_query(self, request, term):
-        results = super(CityLookup, self).get_query(request, term)
-        state = request.GET.get('state', '')
-        if state:
-            results = results.filter(state=state)
-        return results
-
     def get_item_label(self, item):
         return "%s, %s" % (item.name, item.state)
 

--- a/example/core/templates/advanced.html
+++ b/example/core/templates/advanced.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-
+{% load selectable_tags %}
 {% block nav %}
     {% include "nav.html" with page_advanced=True %}
 {% endblock nav %}
@@ -18,11 +18,6 @@
 
 {% block extra-js %}
 <script type="text/javascript">
-    $(document).ready(function() {
-        function newParameters(query) {
-            query.state = $('#id_state').val();
-        }
-        $('#id_city_0').djselectable('option', 'prepareQuery', newParameters);
-    });
+    {{ form|bind_chained_form }}
 </script>
 {% endblock %}

--- a/selectable/registry.py
+++ b/selectable/registry.py
@@ -6,6 +6,68 @@ from selectable.exceptions import (LookupAlreadyRegistered, LookupNotRegistered,
                                     LookupInvalid)
 
 
+def _get_query_decorator(get_query_mtd, parent_entity_name):
+    """
+    This decorator is added on the form's lookup get_query method when the form 
+    is registred in ChainedFormRegistry by the 'chained_field' decorator
+    """
+
+    def get_query(self, request, term):
+        """
+        Lookup get_query method.
+        """
+        results = get_query_mtd( self, request, term)
+        parent_entity = request.GET.get(parent_entity_name, '')
+        if parent_entity:
+            results = results.filter(**{parent_entity_name:parent_entity})
+        return results
+
+    return get_query
+
+
+class ChainedFormRegistry(object):
+    """
+    Decorate get_query lookup method and return chained field to templatetag
+    in order to generate JavaScript code. You must not use this class dirrectly
+    but use the chained_field decorator
+    """
+
+    def __init__(self):
+        self._registry = {}
+        
+    def register(self, form, field_1, field_2):
+        """
+        Called when chained_field(field_1, field_2) decorator is used on the form class.
+        """
+        for field in (field_1, field_2):
+            if not form.base_fields.has_key(field):
+                raise ValueError("class '{}' has not field '{}'".format(form, field))
+
+        lookup_class = form.base_fields.get(field_1).lookup_class
+        lookup_class.get_query = _get_query_decorator(lookup_class.get_query, field_2)
+        self._registry[form] = (field_1, field_2)
+
+    def get(self, form_instance):
+        """
+        Return two chained fields in tuple or (None, None) tuple.
+        """
+        return self._registry.get(type(form_instance), (None, None))
+        
+
+ChainedFormRegistry = ChainedFormRegistry()
+
+
+def chained_field(field_1, field_2):
+    """
+    Decorator for Form class to declare the dependency between two fields.
+    field_1 is week entity of field_2.
+    """
+    def init(cls):
+        ChainedFormRegistry.register(cls, field_1, field_2)
+        return cls
+    return init
+
+
 class LookupRegistry(object):
 
     def __init__(self):

--- a/selectable/templatetags/selectable_tags.py
+++ b/selectable/templatetags/selectable_tags.py
@@ -2,7 +2,8 @@ from __future__ import unicode_literals
 
 from django import template
 from django.conf import settings
-
+from selectable.registry import ChainedFormRegistry
+from django.utils.safestring import mark_safe
 
 register = template.Library()
 
@@ -15,3 +16,31 @@ def include_jquery_libs(version='1.7.2', ui='1.8.23'):
 @register.inclusion_tag('selectable/jquery-css.html')
 def include_ui_theme(theme='base', version='1.8.23'):
     return {'theme': theme, 'version': version}
+
+
+@register.filter
+def bind_chained_form(form):
+    """
+    Generate JavaScript in order to send new parameters to a lookup
+    """
+    field_1, field_2 = ChainedFormRegistry.get(form)
+    if field_1 is None:
+        return ""
+
+    for field in form:
+        if field.name == field_1:
+            child = field.id_for_label
+
+        if field.name == field_2:
+            if field.id_for_label.endswith('_0'):
+                parent = field.id_for_label[:-1] + '1'
+            else :
+                parent = field.id_for_label
+
+    return mark_safe("$(document).ready(function() {{\n" \
+                     "   function newParameters(query) {{\n" \
+                     "       query.state = $('#{parent}').val();\n" \
+                     "    }}\n" \
+                     "    $('#{child}').djselectable('option', 'prepareQuery', newParameters);\n" \
+                     "}});".format(parent=parent, child=child))
+


### PR DESCRIPTION
How to have Chained Selection without write javascript.
============================================

1) Defining simple lookup:

```python
class CityLookup(ModelLookup):
    model = City
    search_fields = ('name__icontains', )

    def get_item_label(self, item):
        return "%s, %s" % (item.name, item.state)
```

2) Defining form and declare the fields dependencys with __chained_field decorator__:

```python
@chained_field('city', 'state')
class ChainedForm(forms.Form):
    city = selectable.AutoCompleteSelectField(
        lookup_class=CityLookup,
        label='City',
        required=False,
        widget=selectable.AutoComboboxSelectWidget
    )
    state = USStateField(widget=USStateSelect, required=False)
```

3) Use __bind_chained_form tag__ in template:

```python
{% extends "base.html" %}
{% load selectable_tags %}
{% block content %}
{{ form.as_p }}
{% endblock %}
{% block extra-js %}
<script type="text/javascript">
    {{ form|bind_chained_form }}
</script>
{% endblock %}
```

Git message commit:
=================

Add 'chained_field' decorator for the Form class. This decorator allow to declare depedency between two fiels. Add 'bind_chained_form' templatetag to generate
JavaScript in order to send new parameters to a lookup. Add 'ChainedFormRegistry'
when 'chained_field' decorator is used on the class form, the form and
the fields are registered in the 'ChainedFormRegistry'. When 'bind_chained_form' templatetag
is called, it get informations in 'ChainedFormRegistry' in order to generate JavaScript.
Update exemple.

Best regard
Vincent