### PR TITLE
Update jquery.dj.selectable.js

### DIFF
--- a/selectable/static/selectable/js/jquery.dj.selectable.js
+++ b/selectable/static/selectable/js/jquery.dj.selectable.js
@@ -334,7 +334,7 @@
     function djangoAdminPatches() {
         /* Listen for new rows being added to the dynamic inlines.
         Requires Django 1.5+ */
-.        $('body').on('click', '.add-row', function (e) {
+        $('body').on('click', '.add-row', function (e) {
             var wrapper = $(this).parents('.inline-related'),
                 newRow = $('.form-row:not(.empty-form)', wrapper).last();
             window.bindSelectables(newRow);


### PR DESCRIPTION
bind to inline add button using delegation method and hence not force it to be rendered on page load.

refs #129
