### PR TITLE
Patch to handle incorrect user label in forms/fields

### DIFF
--- a/selectable/forms/fields.py
+++ b/selectable/forms/fields.py
@@ -77,7 +77,10 @@ class AutoCompleteSelectField(BaseAutoCompleteField):
                         return None
                 if label in EMPTY_VALUES:
                     return None
-                value = lookup.create_item(label)
+                try:
+                    value = lookup.create_item(label)
+                except ValueError:
+                    raise ValidationError(self.error_messages['invalid_choice'])
             else:
                 value = lookup.get_item(pk)
                 if value is None:


### PR DESCRIPTION
I have found that if a user makes changes to the label that is inserted into the lookup field, after the lookup has worked successfully, then an uncaught error occurs.  This patch catches that error, which means the form is redisplayed and the user can correct the error.