### PR TITLE
Update tox Configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,3 +18,7 @@ script:
 branches:
   only:
     - master
+
+matrix:
+  allow_failures:
+    - env: TOXENV=py27-django18,py33-django18

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,10 @@ python:
   - "2.7"
 
 env:
-  - TOXENV=py26-1.5.X,py32-1.5.X
-  - TOXENV=py26-1.6.X,py33-1.6.X
-  - TOXENV=py27-1.7.X,py33-1.7.X
+  - TOXENV=py27-django15,py33-django15
+  - TOXENV=py27-django16,py33-django16
+  - TOXENV=py27-django17,py33-django17
+  - TOXENV=py27-django18,py33-django18
 
 install:
   - pip install tox

--- a/docs/contribute.rst
+++ b/docs/contribute.rst
@@ -58,10 +58,9 @@ against multiple versions of Django/Python. With tox installed you can run::
 to run all the version combinations. You can also run tox against a subset of supported
 environments::
 
-    tox -e py27-1.5.X
+    tox -e py27-django15
 
-This example will run the test against the latest 1.6.X and 1.5.X releases
-using Python 2.6 and 3.2. For more information on running/installing tox please see the
+For more information on running/installing tox please see the
 tox documentation: http://tox.readthedocs.org/en/latest/index.html
 
 Client side tests are written using `QUnit <http://docs.jquery.com/QUnit>`_. They

--- a/tox.ini
+++ b/tox.ini
@@ -1,49 +1,21 @@
 [tox]
 downloadcache = {toxworkdir}/_download/
-envlist = py33-1.8.X,py27-1.8.X,py33-1.7.X,py27-1.7.X,py33-1.6.X,py26-1.6.X,py32-1.5.X,py26-1.5.X,docs
+envlist = {py27,py33}-django{15,16,17,18},docs
 
 [testenv]
+basepython =
+    py27: python2.7
+    py33: python3.3
+deps =
+    django15: Django>=1.5,<1.6
+    django16: Django>=1.6,<1.7
+    django17: Django>=1.7,<1.8
+    django18: https://www.djangoproject.com/download/1.8a1/tarball/
+    py27: mock
 commands = {envpython} runtests.py
 
-[testenv:py33-1.8.X]
-basepython = python3.3
-deps = git+https://github.com/django/django.git#egg=django
-
-[testenv:py27-1.8.X]
-basepython = python2.7
-deps = git+https://github.com/django/django.git#egg=django
-    mock
-
-[testenv:py33-1.7.X]
-basepython = python3.3
-deps = django>=1.7,<1.8
-
-[testenv:py27-1.7.X]
-basepython = python2.7
-deps = django>=1.7,<1.8
-    mock
-
-[testenv:py33-1.6.X]
-basepython = python3.3
-deps = django>=1.6,<1.7
-
-[testenv:py26-1.6.X]
-basepython = python2.6
-deps = django>=1.6,<1.7
-    mock
-
-[testenv:py32-1.5.X]
-basepython = python3.2
-deps = django>=1.5,<1.6
-    mock
-
-[testenv:py26-1.5.X]
-basepython = python2.6
-deps = django>=1.5,<1.6
-    mock
-
 [testenv:docs]
-basepython = python2.6
+basepython = python2.7
 deps =
     Sphinx
     Django>=1.5


### PR DESCRIPTION
Requires tox 1.8 and makes the configuration much easier to read and maintain.