### PR TITLE
Remove JsonResponse in Favor of Built-in

### DIFF
--- a/docs/lookups.rst
+++ b/docs/lookups.rst
@@ -147,16 +147,6 @@ than jQuery UI. Most users will not need to override these methods.
     :return: The current `Page object <https://docs.djangoproject.com/en/stable/topics/pagination/#page-objects>`_
         of results.
 
-.. _lookup-serialize-results:
-
-.. py:method:: LookupBase.serialize_results(self, results)
-
-    Returns serialized results for sending via http. You may choose to override
-    this if you are making use of 
-
-    :param results: a python structure to be serialized e.g. the one returned by :ref:`format_results<lookup-format-results>`
-    :returns: JSON string.
-
 
 .. _ModelLookup:
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -14,6 +14,7 @@ ________________________________
 
 - Dropped support Python 2.6 and 3.2
 - Dropped support for Django < 1.7
+- ``LookupBase.serialize_results`` had been removed. This is now handled by the built-in ``JsonResponse`` in Django.
 
 
 v0.9.0 (Released 2014-10-21)

--- a/selectable/base.py
+++ b/selectable/base.py
@@ -1,7 +1,6 @@
 "Base classes for lookup creation."
 from __future__ import unicode_literals
 
-import json
 import operator
 import re
 from functools import reduce
@@ -9,8 +8,7 @@ from functools import reduce
 from django.conf import settings
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from django.core.urlresolvers import reverse
-from django.core.serializers.json import DjangoJSONEncoder
-from django.http import HttpResponse
+from django.http import JsonResponse
 from django.db.models import Q
 from django.utils.encoding import smart_text
 from django.utils.html import conditional_escape
@@ -23,14 +21,6 @@ __all__ = (
     'LookupBase',
     'ModelLookup',
 )
-
-
-class JsonResponse(HttpResponse):
-    "HttpResponse subclass for returning JSON data."
-
-    def __init__(self, *args, **kwargs):
-        kwargs['content_type'] = 'application/json'
-        super(JsonResponse, self).__init__(*args, **kwargs)
 
 
 class LookupBase(object):
@@ -100,8 +90,7 @@ class LookupBase(object):
             term = options.get('term', '')
             raw_data = self.get_query(request, term)
             results = self.format_results(raw_data, options)
-        content = self.serialize_results(results)
-        return self.response(content)
+        return self.response(results)
 
     def format_results(self, raw_data, options):
         '''
@@ -122,10 +111,6 @@ class LookupBase(object):
         results['data'] = [self.format_item(item) for item in page_data.object_list]
         results['meta'] = meta
         return results
-
-    def serialize_results(self, results):
-        "Returns serialized results for sending via http."
-        return json.dumps(results, cls=DjangoJSONEncoder, ensure_ascii=False)
 
 
 class ModelLookup(LookupBase):


### PR DESCRIPTION
Fixes #143. Removes `serialize_results` method from `LookupBase` which was poorly documented and unlikely to work if changed.