### PR TITLE
jQuery Requirement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,15 +4,16 @@ QUNIT_TESTS = file://`pwd`/selectable/tests/qunit/index.html
 test-js:
 	# Run JS tests
 	# Requires phantomjs
-	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.11.1&ui=1.11.1
+	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.11.2&ui=1.11.4
+	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.11.2&ui=1.10.4
+	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.10.2&ui=1.11.4
 	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.10.2&ui=1.10.4
+	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.9.1&ui=1.11.4
 	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.9.1&ui=1.10.4
-	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.8.3&ui=1.9.2
-	phantomjs run-qunit.js ${QUNIT_TESTS}?jquery=1.7.2&ui=1.8.24
 
 
 lint-js:
-	# Check JS for any problems
+	# Check JS for any problems	
 	# Requires jshint
 	jshint ${STATIC_DIR}/js/jquery.dj.selectable.js
 

--- a/README.rst
+++ b/README.rst
@@ -19,8 +19,8 @@ Installation Requirements
 
 - Python 2.7, 3.3+
 - `Django <http://www.djangoproject.com/>`_ >= 1.7
-- `jQuery <http://jquery.com/>`_ >= 1.7
-- `jQuery UI <http://jqueryui.com/>`_ >= 1.8
+- `jQuery <http://jquery.com/>`_ >= 1.9
+- `jQuery UI <http://jqueryui.com/>`_ >= 1.10
 
 To install::
 
@@ -42,7 +42,7 @@ Once installed you should add the urls to your root url patterns::
 
     urlpatterns = [
         # Other patterns go here
-        (r'^selectable/', include('selectable.urls')),
+        url(r'^selectable/', include('selectable.urls')),
     ]
 
 

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -31,17 +31,17 @@ the  from the `Google CDN <http://code.google.com/apis/libraries/devguide.html#j
         {% load selectable_tags %}
         {% include_jquery_libs %}
 
-By default these will use jQuery v1.7.2 and jQuery UI v1.8.23. You can customize the versions
+By default these will use jQuery v1.11.2 and jQuery UI v1.11.4. You can customize the versions
 used by pass them to the tag. The first version is the jQuery version and the second is the
 jQuery UI version.
 
     .. code-block:: html
 
         {% load selectable_tags %}
-        {% include_jquery_libs '1.4.4' '1.8.13' %}
+        {% include_jquery_libs '1.11.2' '1.11.4' %}
 
-Django-Selectable should work with `jQuery <http://jquery.com/>`_ >= 1.4.4 and
-`jQuery UI <http://jqueryui.com/>`_ >= 1.8.13.
+Django-Selectable should work with `jQuery <http://jquery.com/>`_ >= 1.9 and
+`jQuery UI <http://jqueryui.com/>`_ >= 1.10.
 
 You must also include a `jQuery UI theme <http://jqueryui.com/themeroller/>`_ stylesheet. There
 is also a template tag to easily add this style sheet from the Google CDN.
@@ -51,13 +51,13 @@ is also a template tag to easily add this style sheet from the Google CDN.
         {% load selectable_tags %}
         {% include_ui_theme %}
 
-By default this will use the `base <http://jqueryui.com/themeroller/>`_ theme for jQuery UI v1.8.23.
+By default this will use the `base <http://jqueryui.com/themeroller/>`_ theme for jQuery UI v1.11.4.
 You can configure the theme and version by passing them in the tag.
 
     .. code-block:: html
 
         {% load selectable_tags %}
-        {% include_ui_theme 'ui-lightness' '1.8.13' %}
+        {% include_ui_theme 'ui-lightness' '1.11.4' %}
 
 Or only change the theme.
 
@@ -72,11 +72,11 @@ Of course you can choose to include these rescources manually::
 
     .. code-block:: html
 
-        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/themes/base/jquery-ui.css" type="text/css">
-        <link href="{{ STATIC_URL }}selectable/css/dj.selectable.css" type="text/css" media="all" rel="stylesheet">
-        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.1/jquery.min.js"></script>
-        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.10.0/jquery-ui.js"></script>
-        <script type="text/javascript" src="{{ STATIC_URL }}selectable/js/jquery.dj.selectable.js"></script>
+        <link rel="stylesheet" href="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/themes/base/jquery-ui.css" type="text/css">
+        <link href="{% static 'selectable/css/dj.selectable.css' %}" type="text/css" media="all" rel="stylesheet">
+        <script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.2/jquery.min.js"></script>
+        <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1.11.4/jquery-ui.js"></script>
+        <script type="text/javascript" src="{% static 'selectable/js/jquery.dj.selectable.js' %}"></script>
 
 .. note::
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -15,6 +15,8 @@ ________________________________
 - Dropped support Python 2.6 and 3.2
 - Dropped support for Django < 1.7
 - ``LookupBase.serialize_results`` had been removed. This is now handled by the built-in ``JsonResponse`` in Django.
+- jQuery and jQuery UI versions for the ``include_jquery_libs`` and ``include_ui_theme`` template tags have been increased to 1.11.2 and 1.11.4 respectively.
+- Dropped testing support for jQuery < 1.9 and jQuery UI < 1.10. Earlier versions may continue to work but it is recommended to upgrade.
 
 
 v0.9.0 (Released 2014-10-21)

--- a/selectable/templatetags/selectable_tags.py
+++ b/selectable/templatetags/selectable_tags.py
@@ -8,10 +8,10 @@ register = template.Library()
 
 
 @register.inclusion_tag('selectable/jquery-js.html')
-def include_jquery_libs(version='1.7.2', ui='1.8.23'):
+def include_jquery_libs(version='1.11.2', ui='1.11.4'):
     return {'version': version, 'ui': ui}
 
 
 @register.inclusion_tag('selectable/jquery-css.html')
-def include_ui_theme(theme='base', version='1.8.23'):
+def include_ui_theme(theme='base', version='1.11.4'):
     return {'theme': theme, 'version': version}

--- a/selectable/tests/qunit/jquery-loader.js
+++ b/selectable/tests/qunit/jquery-loader.js
@@ -3,8 +3,8 @@
   var jqversion = location.search.match(/[?&]jquery=(.*?)(?=&|$)/);
   var uiversion = location.search.match(/[?&]ui=(.*?)(?=&|$)/);
   var path;
-  window.jqversion = jqversion && jqversion[1] || '1.7.2';
-  window.uiversion = uiversion && uiversion[1] || '1.8.24';
+  window.jqversion = jqversion && jqversion[1] || '1.11.2';
+  window.uiversion = uiversion && uiversion[1] || '1.11.4';
   jqpath = 'http://code.jquery.com/jquery-' + window.jqversion + '.js';
   uipath = 'http://code.jquery.com/ui/' + window.uiversion + '/jquery-ui.js';
   // This is the only time I'll ever use document.write, I promise!

--- a/selectable/tests/test_templatetags.py
+++ b/selectable/tests/test_templatetags.py
@@ -23,8 +23,8 @@ class JqueryTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_jquery_libs %}")
         context = Context({})
         result = template.render(context)
-        self.assertJQueryVersion(result, '1.7.2')
-        self.assertUIVersion(result, '1.8.23')
+        self.assertJQueryVersion(result, '1.11.2')
+        self.assertUIVersion(result, '1.11.4')
 
     def test_render_jquery_version(self):
         "Render template tag with specified jQuery version."
@@ -82,7 +82,7 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme %}")
         context = Context({})
         result = template.render(context)
-        self.assertUICSS(result, 'base', '1.8.23')
+        self.assertUICSS(result, 'base', '1.11.4')
 
     def test_render_version(self):
         "Render template tag with alternate version."
@@ -104,7 +104,7 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme 'ui-lightness' %}")
         context = Context({})
         result = template.render(context)
-        self.assertUICSS(result, 'ui-lightness', '1.8.23')
+        self.assertUICSS(result, 'ui-lightness', '1.11.4')
         
     def test_variable_theme(self):
         "Render using theme from content variable."
@@ -112,4 +112,4 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme theme %}")
         context = Context({'theme': theme})
         result = template.render(context)
-        self.assertUICSS(result, theme, '1.8.23')
+        self.assertUICSS(result, theme, '1.11.4')


### PR DESCRIPTION
Update minimum expected jQuery version to 1.9 and UI version to 1.10. The Django admin has jQuery 1.9 in 1.7 and jQuery 1.11 in 1.8. Nothing has changed to remove support for older versions but no longer guaranteeing compatibility.