### PR TITLE
multiform support with same id's

### DIFF
--- a/selectable/static/selectable/js/jquery.dj.selectable.js
+++ b/selectable/static/selectable/js/jquery.dj.selectable.js
@@ -31,6 +31,7 @@
         _initDeck: function () {
             /* Create list display for currently selected items for multi-select */
             var self = this;
+            var $input = $(this.element).parent()
             var data = $(this.element).data();
             var style = data.selectablePosition || data['selectable-position'] || 'bottom';
             this.deck = $('<ul>').addClass('ui-widget selectable-deck selectable-deck-' + style);
@@ -39,7 +40,7 @@
             } else {
                 $(this.element).before(this.deck);
             }
-            $(self.hiddenMultipleSelector).each(function (i, input) {
+            $($input).find(self.hiddenMultipleSelector).each(function (i, input) {
                 self._addDeckItem(input);
             });
         },
@@ -93,7 +94,7 @@
                 if (this.allowMultiple) {
                     $input.val("");
                     this.term = "";
-                    if ($(this.hiddenMultipleSelector + '[value="' + item.id + '"]').length === 0) {
+                    if ($($input).find(this.hiddenMultipleSelector + '[value="' + item.id + '"]').length === 0) {
                         var newInput = $('<input />', {
                             'type': 'hidden',
                             'name': this.hiddenName,


### PR DESCRIPTION
We developed a page for editing multiple database object of the same type. Because of this, all (ajax-) forms are identical in html, even the field id's.

At the moment django-selectable is not capable of this situation, so I decided to improve the code to fit our needs.

Because of the simplicity and backwards compatibility with existing usage of this plugin, it should be no problem to merge this change back into the main development branch.