### PR TITLE
support for ajax loaded selectable widgets

### DIFF
--- a/selectable/static/selectable/js/jquery.dj.selectable.js
+++ b/selectable/static/selectable/js/jquery.dj.selectable.js
@@ -377,7 +377,7 @@
         }
     }
 
-    $(document).ready(function () {
+    $(document).on('ready ajaxComplete', function () {
         // Patch the django admin JS
         if (typeof(djselectableAdminPatch) === "undefined" || djselectableAdminPatch) {
             djangoAdminPatches();


### PR DESCRIPTION
We use Ajax to load some django views. To initialize the widget, the init method has to rerun after new html is added to DOM via Ajax.

https://api.jquery.com/ajaxcomplete/