### PR TITLE
Fix example app: python2 unicode compatible when using python3

### DIFF
--- a/example/core/models.py
+++ b/example/core/models.py
@@ -1,5 +1,7 @@
 from __future__ import unicode_literals
 
+from six import python_2_unicode_compatible
+
 try:
     from localflavor.us.models import USStateField
 except ImportError:
@@ -7,25 +9,28 @@ except ImportError:
 from django.db import models
 
 
+@python_2_unicode_compatible
 class Fruit(models.Model):
     name = models.CharField(max_length=200)
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name
 
 
+@python_2_unicode_compatible
 class Farm(models.Model):
     name = models.CharField(max_length=200)
     owner = models.ForeignKey('auth.User', related_name='farms')
     fruit = models.ManyToManyField(Fruit)
 
-    def __unicode__(self):
+    def __str__(self):
         return "%s's Farm: %s" % (self.owner.username, self.name)
 
 
+@python_2_unicode_compatible
 class City(models.Model):
     name = models.CharField(max_length=200)
     state = USStateField()
 
-    def __unicode__(self):
+    def __str__(self):
         return self.name

--- a/example/core/templates/formset.html
+++ b/example/core/templates/formset.html
@@ -9,7 +9,7 @@
 {% endblock %}
 
 {% block extra-js %}
-<script type="text/javascript" src="http://django-dynamic-formset.googlecode.com/svn/trunk/src/jquery.formset.min.js"></script>
+<script type="text/javascript" src="https://cdnjs.cloudflare.com/ajax/libs/jquery.formset/1.2.2/jquery.formset.min.js"></script>
 <script type="text/javascript">
     $(document).ready(function() {
         $('#id_farm_table tbody tr').formset({


### PR DESCRIPTION
Fix problem when using Python 3: The selectable list show items as: `Fruit Object` instead of `Orange` or  `Apple`.

Replace `jquery formset` link from `googlecode` to `cdnjs`, with is more stable