### PR TITLE
remove 'required' attr from MultipleSelect widgets

### DIFF
--- a/selectable/forms/widgets.py
+++ b/selectable/forms/widgets.py
@@ -218,6 +218,12 @@ class _BaseMultipleSelectWidget(SelectableMultiWidget, SelectableMediaMixin):
             value = self.get_compatible_postdata(data, name)
         return value
 
+    def build_attrs(self, extra_attrs=None, **kwargs):
+        attrs = super(_BaseMultipleSelectWidget, self).build_attrs(extra_attrs, **kwargs)
+        if 'required' in attrs:
+            attrs.pop('required')
+        return attrs
+
     def render(self, name, value, attrs=None):
         if value and not hasattr(value, '__iter__'):
             value = [value]


### PR DESCRIPTION
Fixes #175 

Added removal of `required` attr to _BaseMultipleSelectWidget to fix both combobox multiple and select multiple widgets.
I thought build_attrs was the right place to put removal of the `required` attr.