### PR TITLE
Finalize Release for Recent Django Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,10 @@ env:
   - TOXENV=py27-django19,py34-django19
   - TOXENV=py27-django110,py35-django110
   - TOXENV=py27-django111,py35-django111
-  - TOXENV=py35-django_master
 
 matrix:
   allow_failures:
-    - env: TOXENV=py35-django_master
+    - env: TOXENV=py27-django111,py35-django111
 
 install:
   - pip install tox pip wheel codecov -U

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,17 +3,19 @@ sudo: false
 language: python
 
 python:
-  - "3.4"
+  - "3.5"
 
 env:
   - TOXENV=py27-django17,py33-django17
   - TOXENV=py27-django18,py33-django18
   - TOXENV=py27-django19,py34-django19
-  - TOXENV=py27-django_master,py34-django_master
+  - TOXENV=py27-django110,py35-django110
+  - TOXENV=py27-django111,py35-django111
+  - TOXENV=py35-django_master
 
 matrix:
   allow_failures:
-    - env: TOXENV=py27-django_master,py34-django_master
+    - env: TOXENV=py35-django_master
 
 install:
   - pip install tox pip wheel codecov -U

--- a/AUTHORS.txt
+++ b/AUTHORS.txt
@@ -24,5 +24,9 @@ Thomas Güttler
 Yuri Khrustalev
 @SaeX
 Tam Huynh
+Raphael Merx
+Josh Addington
+Tobias Zanke
+Petr Dlouhy
 
 Thanks for all of your work!

--- a/README.rst
+++ b/README.rst
@@ -21,7 +21,7 @@ Installation Requirements
 -----------------------------------
 
 - Python 2.7, 3.3+
-- `Django <http://www.djangoproject.com/>`_ >= 1.7
+- `Django <http://www.djangoproject.com/>`_ >= 1.7, < 1.11
 - `jQuery <http://jquery.com/>`_ >= 1.9
 - `jQuery UI <http://jqueryui.com/>`_ >= 1.10
 

--- a/README.rst
+++ b/README.rst
@@ -22,8 +22,8 @@ Installation Requirements
 
 - Python 2.7, 3.3+
 - `Django <http://www.djangoproject.com/>`_ >= 1.7, < 1.11
-- `jQuery <http://jquery.com/>`_ >= 1.9
-- `jQuery UI <http://jqueryui.com/>`_ >= 1.10
+- `jQuery <http://jquery.com/>`_ >= 1.9, < 3.0
+- `jQuery UI <http://jqueryui.com/>`_ >= 1.10, < 1.12
 
 To install::
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -8,12 +8,18 @@ v1.0.0 (Released TBD)
 This project has been stable for quite some time and finally declaring a 1.0 release. With
 that comes new policies on official supported versions for Django, Python, jQuery, and jQuery UI.
 
+- New translations for German and Czech.
+- Various bug and compatibility fixes.
+- Updated example project.
+
+Special thanks to Raphael Merx for helping track down issues related to this release
+and an updating the example project to work on Django 1.10.
 
 Backwards Incompatible Changes
 ________________________________
 
 - Dropped support Python 2.6 and 3.2
-- Dropped support for Django < 1.7
+- Dropped support for Django < 1.7. Django 1.11 is not yet supported.
 - ``LookupBase.serialize_results`` had been removed. This is now handled by the built-in ``JsonResponse`` in Django.
 - jQuery and jQuery UI versions for the ``include_jquery_libs`` and ``include_ui_theme`` template tags have been increased to 1.11.2 and 1.11.3 respectively.
 - Dropped testing support for jQuery < 1.9 and jQuery UI < 1.10. Earlier versions may continue to work but it is recommended to upgrade.

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -21,7 +21,7 @@ ________________________________
 - Dropped support Python 2.6 and 3.2
 - Dropped support for Django < 1.7. Django 1.11 is not yet supported.
 - ``LookupBase.serialize_results`` had been removed. This is now handled by the built-in ``JsonResponse`` in Django.
-- jQuery and jQuery UI versions for the ``include_jquery_libs`` and ``include_ui_theme`` template tags have been increased to 1.11.2 and 1.11.3 respectively.
+- jQuery and jQuery UI versions for the ``include_jquery_libs`` and ``include_ui_theme`` template tags have been increased to 1.12.4 and 1.11.4 respectively.
 - Dropped testing support for jQuery < 1.9 and jQuery UI < 1.10. Earlier versions may continue to work but it is recommended to upgrade.
 
 

--- a/selectable/base.py
+++ b/selectable/base.py
@@ -9,7 +9,7 @@ from django.conf import settings
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
 from django.core.urlresolvers import reverse
 from django.http import JsonResponse
-from django.db.models import Q
+from django.db.models import Q, Model
 from django.utils.encoding import smart_text
 from django.utils.html import conditional_escape
 from django.utils.translation import ugettext as _
@@ -142,6 +142,7 @@ class ModelLookup(LookupBase):
     def get_item(self, value):
         item = None
         if value:
+            value = value.pk if isinstance(value, Model) else value
             try:
                 item = self.get_queryset().get(pk=value)
             except (ValueError, self.model.DoesNotExist):

--- a/selectable/templatetags/selectable_tags.py
+++ b/selectable/templatetags/selectable_tags.py
@@ -1,17 +1,15 @@
 from __future__ import unicode_literals
 
 from django import template
-from django.conf import settings
-
 
 register = template.Library()
 
 
 @register.inclusion_tag('selectable/jquery-js.html')
-def include_jquery_libs(version='1.11.2', ui='1.11.3'):
+def include_jquery_libs(version='1.12.4', ui='1.11.4'):
     return {'version': version, 'ui': ui}
 
 
 @register.inclusion_tag('selectable/jquery-css.html')
-def include_ui_theme(theme='smoothness', version='1.11.3'):
+def include_ui_theme(theme='smoothness', version='1.11.4'):
     return {'theme': theme, 'version': version}

--- a/selectable/tests/test_functional.py
+++ b/selectable/tests/test_functional.py
@@ -78,26 +78,46 @@ class FuncAutoCompleteSelectTestCase(BaseSelectableTestCase):
         form = OtherThingForm(data=data)
         self.assertFalse(form.is_valid(), 'Form should not be valid')
         rendered_form = form.as_p()
-        inputs = parsed_inputs(rendered_form)
         # Selected text should be populated
-        thing_0 = inputs['thing_0'][0]
-        self.assertEqual(thing_0.attributes['value'].value, self.test_thing.name)
+        self.assertInHTML(
+            '''
+            <input data-selectable-allow-new="false" data-selectable-type="text"
+                data-selectable-url="/selectable-tests/selectable-thinglookup/"
+                id="id_thing_0" name="thing_0" type="text" value="{}" required />
+            '''.format(self.test_thing.name),
+            rendered_form
+        )
         # Selected pk should be populated
-        thing_1 = inputs['thing_1'][0]
-        self.assertEqual(int(thing_1.attributes['value'].value), self.test_thing.pk)
+        self.assertInHTML(
+            '''
+            <input data-selectable-type="hidden" name="thing_1" id="id_thing_1"
+                type="hidden" value="{}" required />
+            '''.format(self.test_thing.pk),
+            rendered_form,
+        )
 
     def test_populate_from_model(self):
         "Populate from existing model."
         other_thing = OtherThing.objects.create(thing=self.test_thing, name='a')
         form = OtherThingForm(instance=other_thing)
         rendered_form = form.as_p()
-        inputs = parsed_inputs(rendered_form)
         # Selected text should be populated
-        thing_0 = inputs['thing_0'][0]
-        self.assertEqual(thing_0.attributes['value'].value, self.test_thing.name)
+        self.assertInHTML(
+            '''
+            <input data-selectable-allow-new="false" data-selectable-type="text"
+                data-selectable-url="/selectable-tests/selectable-thinglookup/"
+                id="id_thing_0" name="thing_0" type="text" value="{}" required />
+            '''.format(self.test_thing.name),
+            rendered_form
+        )
         # Selected pk should be populated
-        thing_1 = inputs['thing_1'][0]
-        self.assertEqual(int(thing_1.attributes['value'].value), self.test_thing.pk)
+        self.assertInHTML(
+            '''
+            <input data-selectable-type="hidden" name="thing_1" id="id_thing_1"
+                type="hidden" value="{}" required />
+            '''.format(self.test_thing.pk),
+            rendered_form,
+        )
 
 
 class SelectWidgetForm(forms.ModelForm):

--- a/selectable/tests/test_functional.py
+++ b/selectable/tests/test_functional.py
@@ -8,7 +8,7 @@ from django import forms
 from ..forms import AutoCompleteSelectField, AutoCompleteSelectMultipleField
 from ..forms import AutoCompleteSelectWidget, AutoComboboxSelectWidget
 from . import ManyThing, OtherThing, ThingLookup
-from .base import BaseSelectableTestCase, parsed_inputs
+from .base import BaseSelectableTestCase
 
 
 __all__ = (
@@ -83,16 +83,18 @@ class FuncAutoCompleteSelectTestCase(BaseSelectableTestCase):
             '''
             <input data-selectable-allow-new="false" data-selectable-type="text"
                 data-selectable-url="/selectable-tests/selectable-thinglookup/"
-                id="id_thing_0" name="thing_0" type="text" value="{}" required />
-            '''.format(self.test_thing.name),
+                id="id_thing_0" name="thing_0" type="text" value="{}" {} />
+            '''.format(self.test_thing.name,
+                       'required' if hasattr(form, 'use_required_attribute') else ''),
             rendered_form
         )
         # Selected pk should be populated
         self.assertInHTML(
             '''
             <input data-selectable-type="hidden" name="thing_1" id="id_thing_1"
-                type="hidden" value="{}" required />
-            '''.format(self.test_thing.pk),
+                type="hidden" value="{}" {} />
+            '''.format(self.test_thing.pk,
+                       'required' if hasattr(form, 'use_required_attribute') else ''),
             rendered_form,
         )
 
@@ -106,17 +108,19 @@ class FuncAutoCompleteSelectTestCase(BaseSelectableTestCase):
             '''
             <input data-selectable-allow-new="false" data-selectable-type="text"
                 data-selectable-url="/selectable-tests/selectable-thinglookup/"
-                id="id_thing_0" name="thing_0" type="text" value="{}" required />
-            '''.format(self.test_thing.name),
+                id="id_thing_0" name="thing_0" type="text" value="{}" {} />
+            '''.format(self.test_thing.name,
+                       'required' if hasattr(form, 'use_required_attribute') else ''),
             rendered_form
         )
         # Selected pk should be populated
         self.assertInHTML(
             '''
             <input data-selectable-type="hidden" name="thing_1" id="id_thing_1"
-                type="hidden" value="{}" required />
-            '''.format(self.test_thing.pk),
-            rendered_form,
+                type="hidden" value="{}" {} />
+            '''.format(self.test_thing.pk,
+                       'required' if hasattr(form, 'use_required_attribute') else ''),
+            rendered_form
         )
 
 

--- a/selectable/tests/test_templatetags.py
+++ b/selectable/tests/test_templatetags.py
@@ -23,8 +23,8 @@ class JqueryTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_jquery_libs %}")
         context = Context({})
         result = template.render(context)
-        self.assertJQueryVersion(result, '1.11.2')
-        self.assertUIVersion(result, '1.11.3')
+        self.assertJQueryVersion(result, '1.12.4')
+        self.assertUIVersion(result, '1.11.4')
 
     def test_render_jquery_version(self):
         "Render template tag with specified jQuery version."
@@ -82,7 +82,7 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme %}")
         context = Context({})
         result = template.render(context)
-        self.assertUICSS(result, 'smoothness', '1.11.3')
+        self.assertUICSS(result, 'smoothness', '1.11.4')
 
     def test_render_version(self):
         "Render template tag with alternate version."
@@ -104,7 +104,7 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme 'ui-lightness' %}")
         context = Context({})
         result = template.render(context)
-        self.assertUICSS(result, 'ui-lightness', '1.11.3')
+        self.assertUICSS(result, 'ui-lightness', '1.11.4')
 
     def test_variable_theme(self):
         "Render using theme from content variable."
@@ -112,4 +112,4 @@ class ThemeTagTestCase(BaseSelectableTestCase):
         template = Template("{% load selectable_tags %}{% include_ui_theme theme %}")
         context = Context({'theme': theme})
         result = template.render(context)
-        self.assertUICSS(result, theme, '1.11.3')
+        self.assertUICSS(result, theme, '1.11.4')

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33}-django{17,18},py{27,34,35}-django{19,_master},docs
+envlist = py{27,33}-django{17,18},py{27,34,35}-django{19,110,111},py35-django_master,docs
 
 [testenv]
 basepython =
@@ -12,12 +12,14 @@ deps =
     django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
+    django110: Django>=1.10,<1.11
+    django111: Django>=1.11,<2.0
     django_master: https://github.com/django/django/archive/master.tar.gz
     py27: mock
 commands = coverage run runtests.py
 
 [testenv:docs]
-basepython = python3.4
+basepython = python3.5
 deps =
     Sphinx
     Django


### PR DESCRIPTION
Currently there are a few errors tracking on 1.10 and 1.11. Master has deprecation problems as well but that's not a priority at the moment.

- [x] Fix test failures
- [x] Sanity check front-end JS
- [x] Sanity check admin
- [ ] Update release notes/set release date
- [x] Confirm translation status
- [ ] Merge and publish to PyPi