### PR TITLE
Deprecations

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,6 @@ python:
   - "3.5"
 
 env:
-  - TOXENV=py27-django17,py33-django17
   - TOXENV=py27-django18,py33-django18
   - TOXENV=py27-django19,py34-django19
   - TOXENV=py27-django110,py35-django110

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -9,6 +9,9 @@ Primarily a Django support related release. This version adds support for Django
 dropping support for Django 1.7. A number of deprecation warnings for future Django
 versions have also been addressed.
 
+Added the ability to search on multiple terms split by whitespace.
+
+
 Backwards Incompatible Changes
 ________________________________
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -2,6 +2,19 @@ Release Notes
 ==================
 
 
+v1.1.0 (Released TBD)
+--------------------------------------
+
+Primarily a Django support related release. This version adds support for Django 1.11 while
+dropping support for Django 1.7. A number of deprecation warnings for future Django
+versions have also been addressed.
+
+Backwards Incompatible Changes
+________________________________
+
+- Dropped support for Django 1.7
+
+
 v1.0.0 (Released 2017-04-14)
 --------------------------------------
 

--- a/example/core/models.py
+++ b/example/core/models.py
@@ -1,12 +1,9 @@
 from __future__ import unicode_literals
 
+from django.db import models
 from django.utils.six import python_2_unicode_compatible
 
-try:
-    from localflavor.us.models import USStateField
-except ImportError:
-    from django.contrib.localflavor.us.models import USStateField
-from django.db import models
+from localflavor.us.models import USStateField
 
 
 @python_2_unicode_compatible
@@ -20,7 +17,7 @@ class Fruit(models.Model):
 @python_2_unicode_compatible
 class Farm(models.Model):
     name = models.CharField(max_length=200)
-    owner = models.ForeignKey('auth.User', related_name='farms')
+    owner = models.ForeignKey('auth.User', related_name='farms', on_delete=models.CASCADE)
     fruit = models.ManyToManyField(Fruit)
 
     def __str__(self):

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -61,18 +61,10 @@ STATICFILES_DIRS = (
     os.path.join(BASE_DIR, 'static'),
 )
 
-# List of finder classes that know how to find static files in
-# various locations.
-STATICFILES_FINDERS = (
-    'django.contrib.staticfiles.finders.FileSystemFinder',
-    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
-#    'django.contrib.staticfiles.finders.DefaultStorageFinder',
-)
-
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '9i1lt2qz$#&amp;21tqxqhq@ep21(8f#^kpih!5yynr+ba1sq5w8+&amp;'
 
-MIDDLEWARE_CLASSES = (
+MIDDLEWARE = (
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,14 +1,9 @@
 from django.conf.urls import include, url
-
-# Uncomment the next two lines to enable the admin:
 from django.contrib import admin
-admin.autodiscover()
+
 
 urlpatterns = [
-    # Uncomment the admin/doc line below to enable admin documentation:
-    # (r'^admin/doc/', include('django.contrib.admindocs.urls')),
-
-    url(r'^admin/', include(admin.site.urls)),
+    url(r'^admin/', admin.site.urls),
     url(r'^selectable/', include('selectable.urls')),
     url(r'^', include('core.urls')),
 ]

--- a/runtests.py
+++ b/runtests.py
@@ -13,11 +13,10 @@ if not settings.configured:
                 'NAME': ':memory:',
             }
         },
-        MIDDLEWARE_CLASSES=(),
+        MIDDLEWARE=(),
         INSTALLED_APPS=(
             'selectable',
         ),
-        SITE_ID=1,
         SECRET_KEY='super-secret',
         ROOT_URLCONF='selectable.tests.urls',
         TEMPLATES=[{

--- a/selectable/__init__.py
+++ b/selectable/__init__.py
@@ -1,6 +1,6 @@
 "Auto-complete selection widgets using Django and jQuery UI."
 
 
-__version__ = '1.1.0'
+__version__ = '1.2.0dev'
 
 default_app_config = 'selectable.apps.SelectableConfig'

--- a/selectable/base.py
+++ b/selectable/base.py
@@ -7,15 +7,14 @@ from functools import reduce
 
 from django.conf import settings
 from django.core.paginator import Paginator, InvalidPage, EmptyPage
-from django.core.urlresolvers import reverse
 from django.http import JsonResponse
 from django.db.models import Q, Model
 from django.utils.encoding import smart_text
 from django.utils.html import conditional_escape
 from django.utils.translation import ugettext as _
 
-from selectable.forms import BaseLookupForm
-
+from .compat import reverse
+from .forms import BaseLookupForm
 
 __all__ = (
     'LookupBase',

--- a/selectable/compat.py
+++ b/selectable/compat.py
@@ -3,4 +3,11 @@
 try:
     from urllib.parse import urlparse
 except ImportError:
+    # This can be removed when Python 2.7 support is dropped
     from urlparse import urlparse
+
+try:
+    from django.urls import reverse
+except ImportError:
+    # This can be removed when Django < 1.9 support is dropped
+    from django.core.urlresolvers import reverse

--- a/selectable/tests/__init__.py
+++ b/selectable/tests/__init__.py
@@ -20,7 +20,7 @@ class Thing(models.Model):
 @python_2_unicode_compatible
 class OtherThing(models.Model):
     name = models.CharField(max_length=100)
-    thing = models.ForeignKey(Thing)
+    thing = models.ForeignKey(Thing, on_delete=models.CASCADE)
 
     def __str__(self):
         return self.name

--- a/selectable/tests/test_base.py
+++ b/selectable/tests/test_base.py
@@ -1,10 +1,10 @@
 from __future__ import unicode_literals
 
-from django.core.urlresolvers import reverse
 from django.utils.html import escape
 from django.utils.safestring import SafeData, mark_safe
 
 from ..base import ModelLookup
+from ..compat import reverse
 from . import Thing
 from .base import BaseSelectableTestCase, SimpleModelLookup
 

--- a/selectable/tests/test_views.py
+++ b/selectable/tests/test_views.py
@@ -3,9 +3,9 @@ from __future__ import division
 import json
 
 from django.conf import settings
-from django.core.urlresolvers import reverse
 from django.test import override_settings
 
+from ..compat import reverse
 from . import ThingLookup
 from .base import BaseSelectableTestCase
 

--- a/selectable/tests/views.py
+++ b/selectable/tests/views.py
@@ -1,9 +1,9 @@
 from django.http import HttpResponseNotFound, HttpResponseServerError
 
 
-def test_404(request):
+def test_404(request, *args, **kwargs):
     return HttpResponseNotFound()
 
 
-def test_500(request):
+def test_500(request, *args, **kwargs):
     return HttpResponseServerError()

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,33}-django{17,18},py{27,34,35}-django{19,110,111},py35-django_master,docs
+envlist = py{27,33}-django{18},py{27,34,35}-django{19,110,111},py35-django_master,docs
 
 [testenv]
 basepython =

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,6 @@ basepython =
     py35: python3.5
 deps =
     coverage>=4.0,<4.1
-    django17: Django>=1.7,<1.8
     django18: Django>=1.8,<1.9
     django19: Django>=1.9,<1.10
     django110: Django>=1.10,<1.11


### PR DESCRIPTION
Now that Django 1.11 support has landed this updates some of the code yielding deprecation warnings on Django 1.11. There is one that isn't addressed which is related to the new `renderer` argument for the widget class. This arg is only supported on 1.11 and it won't be deprecated until 2.1.  It doesn't seem worth jumping through all of those hoops until 1.11 is the minimum supported version (which will probably be the release after this).