### PR TITLE
Django 2.1 Compat

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,12 @@ addons:
     - python2.7
     - python3.4
     - python3.6
+    - python3.7
 
 env:
   - TOXENV=py27-django111,py34-django111,py35-django111,py36-django111
-  - TOXENV=py34-django20,py35-django20,py36-django20
+  - TOXENV=py34-django20,py35-django20,py36-django20,py37-django20
+  - TOXENV=py35-django21,py36-django21,py37-django21
 
 install:
   - pip install tox pip wheel codecov -U

--- a/README.rst
+++ b/README.rst
@@ -34,7 +34,7 @@ Installation Requirements
 -----------------------------------
 
 - Python 2.7, 3.4+
-- `Django <http://www.djangoproject.com/>`_ >= 1.11, <= 2.0
+- `Django <http://www.djangoproject.com/>`_ >= 1.11, <= 2.1
 - `jQuery <http://jquery.com/>`_ >= 1.9, < 3.0
 - `jQuery UI <http://jqueryui.com/>`_ >= 1.10, < 1.12
 

--- a/docs/releases.rst
+++ b/docs/releases.rst
@@ -5,7 +5,7 @@ Release Notes
 v1.2.0 (Released TBD)
 --------------------------------------
 
-Primarily a Django support related release. This version adds support for Django 2.0 while
+Primarily a Django support related release. This version adds support for Django 2.0 and 2.1 while
 dropping support for Django versions below 1.11. A number of deprecation warnings for future Django
 versions have also been addressed.
 

--- a/example/example/settings.py
+++ b/example/example/settings.py
@@ -57,21 +57,21 @@ STATIC_ROOT = ''
 STATIC_URL = '/static/'
 
 # Additional locations of static files
-STATICFILES_DIRS = (
+STATICFILES_DIRS = [
     os.path.join(BASE_DIR, 'static'),
-)
+]
 
 # Make this unique, and don't share it with anybody.
 SECRET_KEY = '9i1lt2qz$#&amp;21tqxqhq@ep21(8f#^kpih!5yynr+ba1sq5w8+&amp;'
 
-MIDDLEWARE = (
+MIDDLEWARE = [
     'django.middleware.common.CommonMiddleware',
     'django.contrib.sessions.middleware.SessionMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
-)
+]
 
 ROOT_URLCONF = 'example.urls'
 
@@ -101,7 +101,7 @@ TEMPLATES = [
     },
 ]
 
-INSTALLED_APPS = (
+INSTALLED_APPS = [
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
@@ -110,7 +110,7 @@ INSTALLED_APPS = (
     'django.contrib.admin',
     'selectable',
     'core',
-)
+]
 
 # A sample logging configuration. The only tangible logging
 # performed by this configuration is to send an email to

--- a/example/example/urls.py
+++ b/example/example/urls.py
@@ -1,9 +1,9 @@
-from django.conf.urls import include, url
+from django.urls import include, path
 from django.contrib import admin
 
 
 urlpatterns = [
-    url(r'^admin/', admin.site.urls),
-    url(r'^selectable/', include('selectable.urls')),
-    url(r'^', include('core.urls')),
+    path('admin/', admin.site.urls),
+    path('selectable/', include('selectable.urls')),
+    path('', include('core.urls')),
 ]

--- a/example/requirements.txt
+++ b/example/requirements.txt
@@ -1,2 +1,2 @@
-django>=1.11
+django>=2.1
 django-localflavor

--- a/selectable/tests/base.py
+++ b/selectable/tests/base.py
@@ -3,7 +3,7 @@ from __future__ import unicode_literals
 import random
 import string
 from collections import defaultdict
-from xml.dom.minidom import parseString
+import html5lib
 
 
 from django.test import TestCase, override_settings
@@ -14,7 +14,7 @@ from ..base import ModelLookup
 
 def as_xml(html):
     "Convert HTML portion to minidom node."
-    return parseString('<root>%s</root>' % html)
+    return html5lib.parse(html, treebuilder="dom")
 
 
 def parsed_inputs(html):

--- a/selectable/tests/test_functional.py
+++ b/selectable/tests/test_functional.py
@@ -398,7 +398,7 @@ class FuncFormTestCase(BaseSelectableTestCase):
             'things_0': '',
             'things_1': [self.test_thing.pk, ]
         }
-        form = SimpleForm(data=data, empty_permitted=True)
+        form = SimpleForm(data=data, empty_permitted=True, use_required_attribute=False)
         self.assertTrue(form.has_changed())
         self.assertTrue(form.is_valid(), str(form.errors))
 
@@ -442,7 +442,10 @@ class FuncFormTestCase(BaseSelectableTestCase):
             'new_thing': '',
             'things': '',
         }
-        form = SimpleForm(data=data, initial=initial, empty_permitted=True)
+        form = SimpleForm(
+            data=data, initial=initial, empty_permitted=True,
+            use_required_attribute=False
+        )
         self.assertFalse(form.has_changed(), str(form.changed_data))
         self.assertTrue(form.is_valid(), str(form.errors))
 
@@ -459,7 +462,7 @@ class FuncFormTestCase(BaseSelectableTestCase):
             'things_0': '',
             'things_1': '',
         }
-        form = SimpleForm(data=data, empty_permitted=True)
+        form = SimpleForm(data=data, empty_permitted=True, use_required_attribute=False)
         self.assertFalse(form.has_changed(), str(form.changed_data))
         self.assertTrue(form.is_valid(), str(form.errors))
 
@@ -468,7 +471,7 @@ class FuncFormTestCase(BaseSelectableTestCase):
         If no data is submitted and allowed with no initial then
         the form should not be seen as changed.
         """
-        form = SimpleForm(data={}, empty_permitted=True)
+        form = SimpleForm(data={}, empty_permitted=True, use_required_attribute=False)
         self.assertFalse(form.has_changed(), str(form.changed_data))
         self.assertTrue(form.is_valid(), str(form.errors))
 

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,7 @@ setup(
         'Framework :: Django',
         'Framework :: Django :: 1.11',
         'Framework :: Django :: 2.0',
+        'Framework :: Django :: 2.1',
         'License :: OSI Approved :: BSD License',
         'Operating System :: OS Independent',
         'Programming Language :: Python',
@@ -37,10 +38,11 @@ setup(
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Topic :: Internet :: WWW/HTTP :: Dynamic Content',
     ],
     long_description=read_file('README.rst'),
     test_suite="runtests.runtests",
-    tests_require=['mock'],
+    tests_require=['mock', 'html5lib'],
     zip_safe=False,  # because we're including media that Django needs
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{27,34,35,36}-django{111},py{34,35,36}-django20,py35-django_master,docs
+envlist = py{27,34,35,36}-django{111},py{34,35,36,37}-django20,py{35,36,37}-django21,py37-django_master,docs
 
 [testenv]
 basepython =
@@ -7,10 +7,13 @@ basepython =
     py34: python3.4
     py35: python3.5
     py36: python3.6
+    py37: python3.7
 deps =
     coverage>=4.0,<4.1
+    html5lib>=1.0.1,<1.1
     django111: Django>=1.11,<2.0
     django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     django_master: https://github.com/django/django/archive/master.tar.gz
     py27: mock
 commands = coverage run runtests.py


### PR DESCRIPTION
Updates to support Django 2.1 (mostly test fixes).

I had to swap out the `xml.dom.minidom` parser to `html5lib` as Django 2.1 no longer includes a closing slash on void elements, which is incompatible within XHTML. I also added python3.7 to the test matrix.

I did not update the version number, since 1.2.0 was never officially released.