### PR TITLE
Update selectable/forms/fields.py

### DIFF
--- a/selectable/forms/fields.py
+++ b/selectable/forms/fields.py
@@ -28,6 +28,10 @@ class BaseAutoCompleteField(forms.Field):
 
     def has_changed(self, initial, data):
         "Detects if the data was changed. This is added in 1.6."
+        # Always return False if the field is disabled since self.bound_data
+        # always uses the initial value in this case.
+        if self.disabled:
+            return False
         if initial is None and data is None:
             return False
         if data and not hasattr(data, '__iter__'):


### PR DESCRIPTION
If selectable field is disabled in forms.py, has_changed() method returns True and form's method has_changed() returns True even if nothing changed.
I propose adding 4 lines (31-34), copied from Django's class Field, method has_changed() (https://github.com/django/django/blob/master/django/forms/fields.py, lines 175-178). This fixes unwanted behavior.